### PR TITLE
Clean up counter action.

### DIFF
--- a/client/actions/counter.js
+++ b/client/actions/counter.js
@@ -3,7 +3,7 @@ import { createAction } from 'redux-actions'
 // ------------------------------------
 // Actions
 // ------------------------------------
-export const increment = createAction('increment counter', (value = 1) => value)
+export const increment = createAction('increment counter')
 
 // This is a thunk, meaning it is a function that immediately
 // returns a function for lazy evaluation. It is incredibly useful for


### PR DESCRIPTION
Per redux-actions docs, since we're giving the counter reducer a default state
of 1 in handleActions(), we don't need to specify a default value in
createAction(). The default payload creator is the identity function, so we can
leave out the second parameter passed to createAction altogether.