### PR TITLE
Remove config.compiler_enable_hmr.

### DIFF
--- a/build/webpack/_development.js
+++ b/build/webpack/_development.js
@@ -13,45 +13,39 @@ export default (webpackConfig) => {
   // ------------------------------------
   // Enable HMR if Configured
   // ------------------------------------
-  if (config.compiler_enable_hmr) {
-    debug('Enable Hot Module Replacement (HMR).')
+  debug('Enable Hot Module Replacement (HMR).')
 
-    webpackConfig.entry.app.push(
-      'webpack-hot-middleware/client?path=/__webpack_hmr'
-    )
+  webpackConfig.entry.app.push(
+    'webpack-hot-middleware/client?path=/__webpack_hmr'
+  )
 
-    webpackConfig.plugins.push(
-      new webpack.HotModuleReplacementPlugin(),
-      new webpack.NoErrorsPlugin()
-    )
+  webpackConfig.plugins.push(
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
+  )
 
-    webpackConfig.eslint.emitWarning = true
+  webpackConfig.eslint.emitWarning = true
 
-    // We need to apply the react-transform HMR plugin to the Babel
-    // configuration, but _only_ when HMR is enabled. Putting this in the
-    // default development configuration will break other tasks because Webpack
-    // HMR is not enabled there, and these transforms require it.
-    webpackConfig.module.loaders = webpackConfig.module.loaders.map(loader => {
-      if (/babel/.test(loader.loader)) {
-        debug('Apply react-transform-hmr to babel development transforms')
+  webpackConfig.module.loaders = webpackConfig.module.loaders.map(loader => {
+    if (/babel/.test(loader.loader)) {
+      debug('Apply react-transform-hmr to babel development transforms')
 
-        if (loader.query.env.development.plugins[0][0] !== 'react-transform') {
-          debug('ERROR: react-transform must be the first plugin')
-          return loader
-        }
-
-        const reactTransformHmr = {
-          transform: 'react-transform-hmr',
-          imports: ['react'],
-          locals: ['module']
-        }
-        loader.query.env.development.plugins[0][1].transforms
-          .push(reactTransformHmr)
+      if (loader.query.env.development.plugins[0][0] !== 'react-transform') {
+        debug('ERROR: react-transform must be the first plugin')
+        return loader
       }
 
-      return loader
-    })
-  }
+      const reactTransformHmr = {
+        transform: 'react-transform-hmr',
+        imports: ['react'],
+        locals: ['module']
+      }
+      loader.query.env.development.plugins[0][1].transforms
+        .push(reactTransformHmr)
+    }
+
+    return loader
+  })
 
   return webpackConfig
 }

--- a/config/default.js
+++ b/config/default.js
@@ -26,7 +26,6 @@ const config = {
   // Compiler Configuration
   // ----------------------------------
   compiler_css_modules: true,
-  compiler_enable_hmr: false,
   compiler_source_maps: true,
   compiler_hash_type: 'hash',
   compiler_fail_on_warning: false,

--- a/config/development.js
+++ b/config/development.js
@@ -1,17 +1,10 @@
-import { argv } from 'yargs'
 import baseConfig from './default'
-
-const HMR_ENABLED = !!argv.hot
-const config = {
-  env: process.env.NODE_ENV,
-  compiler_enable_hmr: HMR_ENABLED
-}
 
 // We use an explicit public path when the assets are served by webpack
 // to fix this issue:
 // http://stackoverflow.com/questions/34133808/webpack-ots-parsing-error-loading-fonts/34133809#34133809
-if (HMR_ENABLED) {
-  config.compiler_public_path = (
+const config = {
+  compiler_public_path: (
     `http://${baseConfig.server_host}:${baseConfig.server_port}/`
   )
 }

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "redux": "^3.0.0",
     "redux-actions": "^0.9.0",
     "redux-simple-router": "^1.0.0",
-    "redux-thunk": "^1.0.0",
-    "yargs": "^3.18.0"
+    "redux-thunk": "^1.0.0"
   },
   "devDependencies": {
     "classnames": "^2.2.1",

--- a/server/http/express/index.js
+++ b/server/http/express/index.js
@@ -11,7 +11,7 @@ app.use(require('./middleware/formatting'))
 
 // final piece - serve static content
 app.use(require('./middleware/spa'))
-if (config.compiler_enable_hmr) {
+if (config.env === 'development') {
   app.use(require('./middleware/webpack'))
 } else {
   app.use(express.static(paths.base(config.dir_dist)))


### PR DESCRIPTION
This felt unnecessary, and I can't think of a reason to disable hmr on dev, or
to use hmr on staging or production, so I am using config.env to determine when
to turn on hmr.