### PR TITLE
Stop webpack from swallowing errors. Closes #91

### DIFF
--- a/server/http/middleware/webpack.js
+++ b/server/http/middleware/webpack.js
@@ -2,19 +2,11 @@ import webpack from 'webpack'
 import {compose} from 'compose-middleware'
 import WebpackDevMiddleware from 'webpack-dev-middleware'
 import WebpackHotMiddleware from 'webpack-hot-middleware'
-import config from 'app-config-chain'
 import webpackConfig from '../../../webpack'
 
 const compiler = webpack(webpackConfig)
 
 export default compose([
-  WebpackDevMiddleware(compiler, {
-    publicPath: config.paths.public,
-    contentBase: config.paths.client,
-    noInfo: true,
-    hot: true,
-    lazy: false,
-    quiet: true
-  }),
+  WebpackDevMiddleware(compiler, webpackConfig.devServer),
   WebpackHotMiddleware(compiler)
 ])

--- a/webpack/development.js
+++ b/webpack/development.js
@@ -1,11 +1,21 @@
 /* eslint key-spacing:0 */
 import webpack from 'webpack'
+import config from 'app-config-chain'
 import _debug from 'debug'
 
 const debug = _debug('build:development')
 
 export default (webpackConfig) => {
   debug('Create configuration.')
+
+  webpackConfig.devServer = {
+    publicPath: config.paths.public,
+    contentBase: config.paths.client,
+    noInfo: true,
+    stats: 'errors-only',
+    hot: true,
+    lazy: false
+  }
 
   // ------------------------------------
   // Enable HMR if Configured


### PR DESCRIPTION
Webpack dev middleware has a few config options for error reporting and stat
output. The noInfo option is supposed to limit output to errors and warnings,
the quiet option is supposed to supress all output, and the stats option which,
from everything I've seen, can take an 'error-only' value, that when used, does
what you'd expect. The strange thing is that I've seen this in a few blog
posts/issues, but if you look in both webpack-dev-middleware and
webpack-hot-middleware, you don't see anything looking for that value.

At any rate, to test this out, just require a module that doesn't exist
somewhere within /client.