### PR TITLE
Use webpack ProvidePlugin to manage jquery dependency.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,5 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src='https://code.jquery.com/jquery-2.2.0.min.js'></script>
 </body>
 </html>

--- a/client/views/Root/index.js
+++ b/client/views/Root/index.js
@@ -5,6 +5,7 @@ import {Component, PropTypes} from 'shasta'
 import './index.sass'
 
 // css
+import 'jquery'
 import 'semantic-ui-css/semantic.css'
 import 'semantic-ui-css/semantic.js'
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "errorhandler": "^1.4.2",
     "express": "^4.13.3",
     "express-session": "^1.13.0",
+    "jquery": "^2.2.0",
     "lodash.filter": "^4.0.0",
     "lodash.foreach": "^4.0.0",
     "lodash.intersection": "^4.0.1",

--- a/webpack/default.js
+++ b/webpack/default.js
@@ -60,6 +60,10 @@ const webpackConfig = {
       minify: {
         collapseWhitespace: true
       }
+    }),
+    new webpack.ProvidePlugin({
+      $: 'jquery',
+      jQuery: 'jquery'
     })
   ],
   resolve: {


### PR DESCRIPTION
We were including jQuery in via a script tag to jquery cdn, as semantic-ui
needed it. ProvidePlugin manages this.

This also touches on #55. It seems like the webpack 'way' is to not move static assets like this. I'm not sure if #55 should be made redundant.